### PR TITLE
Fix/redis adapter hash fixes

### DIFF
--- a/lib/cache/redis.ex
+++ b/lib/cache/redis.ex
@@ -101,7 +101,8 @@ defmodule Cache.Redis do
 
   @impl Cache
   def put(pool_name, key, ttl, value, opts \\ []) do
-    with {:ok, "OK"} <- command(pool_name, redis_set_command(pool_name, key, ttl, value), opts) do
+    with {:ok, "OK"} <-
+           command(pool_name, redis_set_command(pool_name, key, ttl, value), opts) do
       :ok
     end
   end
@@ -137,6 +138,8 @@ defmodule Cache.Redis do
   end
 
   def hash_get(pool_name, key, field, opts) do
+    field = TermEncoder.encode(field, opts[:compression_level])
+
     with {:ok, value} when not is_nil(value) <-
            command(pool_name, ["HGET", cache_key(pool_name, key), field], opts) do
       {:ok, TermEncoder.decode(value)}
@@ -148,8 +151,8 @@ defmodule Cache.Redis do
       hash =
         data
         |> Enum.chunk_every(2)
-        |> Map.new(fn [key, value] ->
-          {TermEncoder.decode(key), TermEncoder.decode(value)}
+        |> Map.new(fn [field, value] ->
+          {TermEncoder.decode(field), TermEncoder.decode(value)}
         end)
 
       {:ok, hash}
@@ -157,6 +160,7 @@ defmodule Cache.Redis do
   end
 
   def hash_set(pool_name, key, field, value, opts) do
+    field = TermEncoder.encode(field, opts[:compression_level])
     value = TermEncoder.encode(value, opts[:compression_level])
 
     command(pool_name, ["HSET", cache_key(pool_name, key), field, value], opts)
@@ -164,13 +168,18 @@ defmodule Cache.Redis do
 
   def hash_set_many(pool_name, key_values, ttl, opts) do
     commands =
-      Enum.map(key_values, fn {key, key_values} ->
-        key_values =
-          Enum.map(key_values, fn {key, value} ->
-            {key, TermEncoder.encode(value, opts[:compression_level])}
+      Enum.map(key_values, fn {key, field_values} ->
+        field_values =
+          field_values
+          |> Enum.map(fn {field, value} ->
+            [
+              TermEncoder.encode(field, opts[:compression_level]),
+              TermEncoder.encode(value, opts[:compression_level])
+            ]
           end)
+          |> List.flatten()
 
-        ["HSET", cache_key(pool_name, key) | key_values]
+        ["HSET", cache_key(pool_name, key) | field_values]
       end)
 
     expiries =
@@ -186,11 +195,19 @@ defmodule Cache.Redis do
   end
 
   def hash_delete(pool_name, key, field, opts) do
+    field = TermEncoder.encode(field, opts[:compression_level])
     command(pool_name, ["HDEL", cache_key(pool_name, key), field], opts)
   end
 
   def hash_values(pool_name, key, opts) do
-    command(pool_name, ["HVALS", cache_key(pool_name, key)], opts)
+    with {:ok, data} <- command(pool_name, ["HVALS", cache_key(pool_name, key)], opts) do
+      values =
+        Enum.map(data, fn value ->
+          TermEncoder.decode(value)
+        end)
+
+      {:ok, values}
+    end
   end
 
   defp cache_key(pool_name, key) do

--- a/lib/cache/sandbox.ex
+++ b/lib/cache/sandbox.ex
@@ -22,7 +22,7 @@ defmodule Cache.Sandbox do
   def child_spec({cache_name, opts}) do
     %{
       id: "#{cache_name}_anana_cache_agent",
-      start: {Cache.Agent, :start_link, [Keyword.put(opts, :name, cache_name)]}
+      start: {__MODULE__, :start_link, [Keyword.put(opts, :name, cache_name)]}
     }
   end
 

--- a/test/cache/redis_test.exs
+++ b/test/cache/redis_test.exs
@@ -1,0 +1,101 @@
+defmodule Cache.RedisTest do
+  @moduledoc """
+  Redis-adapter-specific tests.
+
+  """
+  use ExUnit.Case, async: true
+
+  @cache_name :test_cache_redis_adapter
+
+  defmodule RedisCache do
+    use Cache,
+      adapter: Cache.Redis,
+      name: :test_cache_redis_adapter,
+      opts: [uri: "redis://localhost:6379"]
+  end
+
+  alias __MODULE__.RedisCache
+
+  setup %{test: test} do
+    start_supervised!({Cache, [RedisCache]})
+
+    keys = Cache.Redis.command!(@cache_name, ["KEYS", "#{@cache_name}:#{test_key(test, "*")}"])
+
+    if length(keys) > 0 do
+      Cache.Redis.command!(@cache_name, ["DEL"] ++ keys)
+    end
+
+    :ok
+  end
+
+  describe "&hash_set/3" do
+    test "encodes fields and values in a hash as binaries", %{test: test} do
+      test_key = test_key(test, "key")
+      {:ok, 1} = RedisCache.hash_set(test_key, "field", "value")
+
+      assert {:ok, [<<field::binary>>, <<value::binary>>]} =
+               Cache.Redis.command(@cache_name, ["HGETALL", "#{@cache_name}:#{test_key}"])
+
+      refute String.valid?(field)
+      refute String.valid?(value)
+    end
+  end
+
+  describe "&hash_get/3" do
+    setup :put_hash_key
+
+    test "retrieve's and decodes a value from a hash", %{key: key} do
+      assert {:ok, "value"} = RedisCache.hash_get(key, "field_1")
+    end
+  end
+
+  describe "&hash_delete/3" do
+    setup :put_hash_key
+
+    test "deletes a field from a hash", %{key: key} do
+      assert {:ok, 1} = RedisCache.hash_delete(key, "field_1")
+    end
+  end
+
+  describe "&hash_values/3" do
+    setup :put_hash_key
+
+    test "retrieves and decodes values from a hash", %{key: key} do
+      assert {:ok, ["value", "value"]} = RedisCache.hash_values(key)
+    end
+  end
+
+  describe "&hash_set_many/3" do
+    test "sets many keys", %{test: test} do
+      test_key_1 = test_key(test, "1")
+      test_key_2 = test_key(test, "2")
+
+      set_1 = {test_key_1, [{"field_1", "value"}, {"field_2", "value"}]}
+      set_2 = {test_key_2, [{"field_1", "value"}, {"field_2", "value"}]}
+
+      {:ok, [2]} = RedisCache.hash_set_many([set_1])
+      {:ok, [0, 2]} = RedisCache.hash_set_many([set_1, set_2])
+    end
+  end
+
+  describe "&hash_get_all/3" do
+    setup :put_hash_key
+
+    test "gets complete hash by key", %{key: key} do
+      {:ok, %{"field_1" => "value", "field_2" => "value"}} = RedisCache.hash_get_all(key)
+    end
+  end
+
+  defp test_key(test, key), do: "#{test}:#{key}"
+
+  defp put_hash_key(%{test: test}) do
+    test_key = test_key(test, "key")
+
+    {:ok, [2]} =
+      RedisCache.hash_set_many([
+        {test_key, [{"field_1", "value"}, {"field_2", "value"}]}
+      ])
+
+    {:ok, key: test_key}
+  end
+end

--- a/test/cache/redis_test.exs
+++ b/test/cache/redis_test.exs
@@ -41,7 +41,7 @@ defmodule Cache.RedisTest do
     end
   end
 
-  describe "&hash_get/3" do
+  describe "&hash_get/2" do
     setup :put_hash_key
 
     test "retrieve's and decodes a value from a hash", %{key: key} do
@@ -49,7 +49,7 @@ defmodule Cache.RedisTest do
     end
   end
 
-  describe "&hash_delete/3" do
+  describe "&hash_delete/2" do
     setup :put_hash_key
 
     test "deletes a field from a hash", %{key: key} do
@@ -57,7 +57,7 @@ defmodule Cache.RedisTest do
     end
   end
 
-  describe "&hash_values/3" do
+  describe "&hash_values/1" do
     setup :put_hash_key
 
     test "retrieves and decodes values from a hash", %{key: key} do
@@ -65,7 +65,7 @@ defmodule Cache.RedisTest do
     end
   end
 
-  describe "&hash_set_many/3" do
+  describe "&hash_set_many/1" do
     test "sets many keys", %{test: test} do
       test_key_1 = test_key(test, "1")
       test_key_2 = test_key(test, "2")
@@ -78,7 +78,7 @@ defmodule Cache.RedisTest do
     end
   end
 
-  describe "&hash_get_all/3" do
+  describe "&hash_get_all/1" do
     setup :put_hash_key
 
     test "gets complete hash by key", %{key: key} do

--- a/test/cache_sandbox_test.exs
+++ b/test/cache_sandbox_test.exs
@@ -4,7 +4,7 @@ defmodule CacheSandboxTest do
   defmodule TestCache do
     use Cache,
       adapter: Cache.Redis,
-      name: :test_cache_redis,
+      name: :test_cache_sandbox,
       opts: [uri: "redis://localhost:6379"],
       sandbox?: Mix.env() === :test
   end


### PR DESCRIPTION
- Encodes fields as well as values in hash-based Redis operations in order to fix `&hash_get_all/1` and `&hash_set_many/1`
- Fixes flakiness in the cache_sandbox_test