### PR TITLE
Feature/add redis ops

### DIFF
--- a/lib/cache/redis.ex
+++ b/lib/cache/redis.ex
@@ -41,6 +41,10 @@ defmodule Cache.Redis do
         @cache_adapter.scan(@cache_name, scan_opts, @adapter_opts)
       end
 
+      def hash_scan(key, scan_opts \\ []) do
+        @cache_adapter.hash_scan(@cache_name, key, scan_opts, @adapter_opts)
+      end
+
       def hash_get(key, field) do
         @cache_adapter.hash_get(@cache_name, key, field, @adapter_opts)
       end
@@ -161,6 +165,7 @@ defmodule Cache.Redis do
   defdelegate command!(pool_name, command, opts \\ []), to: Redis.Global
   defdelegate scan(pool_name, scan_opts, opts \\ []), to: Redis.Global
 
+  defdelegate hash_scan(pool_name, key, scan_opts, opts \\ []), to: Redis.Hash
   defdelegate hash_get(pool_name, key, field, opts \\ []), to: Redis.Hash
   defdelegate hash_get_all(pool_name, key, opts \\ []), to: Redis.Hash
   defdelegate hash_get_many(pool_name, key_fields, opts \\ []), to: Redis.Hash

--- a/lib/cache/redis.ex
+++ b/lib/cache/redis.ex
@@ -45,6 +45,10 @@ defmodule Cache.Redis do
         @cache_adapter.hash_get_all(@cache_name, key, @adapter_opts)
       end
 
+      def hash_get_many(key_fields) do
+        @cache_adapter.hash_get_many(@cache_name, key_fields, @adapter_opts)
+      end
+
       def hash_set(key, field, value) do
         @cache_adapter.hash_set(@cache_name, key, field, value, @adapter_opts)
       end
@@ -154,6 +158,7 @@ defmodule Cache.Redis do
 
   defdelegate hash_get(pool_name, key, field, opts \\ []), to: Redis.Hash
   defdelegate hash_get_all(pool_name, key, opts \\ []), to: Redis.Hash
+  defdelegate hash_get_many(pool_name, key_fields, opts \\ []), to: Redis.Hash
   defdelegate hash_set(pool_name, key, field, value, opts \\ []), to: Redis.Hash
   defdelegate hash_set_many(pool_name, key_values, ttl, opts \\ []), to: Redis.Hash
   defdelegate hash_delete(pool_name, key, field, opts \\ []), to: Redis.Hash

--- a/lib/cache/redis.ex
+++ b/lib/cache/redis.ex
@@ -57,8 +57,8 @@ defmodule Cache.Redis do
         @cache_adapter.hash_get_many(@cache_name, key_fields, @adapter_opts)
       end
 
-      def hash_set(key, field, value) do
-        @cache_adapter.hash_set(@cache_name, key, field, value, @adapter_opts)
+      def hash_set(key, field, value, ttl \\ nil) do
+        @cache_adapter.hash_set(@cache_name, key, field, value, ttl, @adapter_opts)
       end
 
       def hash_set_many(keys_fields_values, ttl \\ nil) do
@@ -169,7 +169,7 @@ defmodule Cache.Redis do
   defdelegate hash_get(pool_name, key, field, opts \\ []), to: Redis.Hash
   defdelegate hash_get_all(pool_name, key, opts \\ []), to: Redis.Hash
   defdelegate hash_get_many(pool_name, key_fields, opts \\ []), to: Redis.Hash
-  defdelegate hash_set(pool_name, key, field, value, opts \\ []), to: Redis.Hash
+  defdelegate hash_set(pool_name, key, field, value, ttl, opts \\ []), to: Redis.Hash
   defdelegate hash_set_many(pool_name, key_values, ttl, opts \\ []), to: Redis.Hash
   defdelegate hash_delete(pool_name, key, field, opts \\ []), to: Redis.Hash
   defdelegate hash_values(pool_name, key, opts \\ []), to: Redis.Hash

--- a/lib/cache/redis.ex
+++ b/lib/cache/redis.ex
@@ -37,6 +37,10 @@ defmodule Cache.Redis do
 
   defmacro __using__(_opts) do
     quote do
+      def scan(scan_opts \\ []) do
+        @cache_adapter.scan(@cache_name, scan_opts, @adapter_opts)
+      end
+
       def hash_get(key, field) do
         @cache_adapter.hash_get(@cache_name, key, field, @adapter_opts)
       end
@@ -155,6 +159,7 @@ defmodule Cache.Redis do
   defdelegate pipeline!(pool_name, command, opts \\ []), to: Redis.Global
   defdelegate command(pool_name, command, opts \\ []), to: Redis.Global
   defdelegate command!(pool_name, command, opts \\ []), to: Redis.Global
+  defdelegate scan(pool_name, scan_opts, opts \\ []), to: Redis.Global
 
   defdelegate hash_get(pool_name, key, field, opts \\ []), to: Redis.Hash
   defdelegate hash_get_all(pool_name, key, opts \\ []), to: Redis.Hash

--- a/lib/cache/redis.ex
+++ b/lib/cache/redis.ex
@@ -170,7 +170,7 @@ defmodule Cache.Redis do
   defdelegate hash_get_all(pool_name, key, opts \\ []), to: Redis.Hash
   defdelegate hash_get_many(pool_name, key_fields, opts \\ []), to: Redis.Hash
   defdelegate hash_set(pool_name, key, field, value, ttl, opts \\ []), to: Redis.Hash
-  defdelegate hash_set_many(pool_name, key_values, ttl, opts \\ []), to: Redis.Hash
+  defdelegate hash_set_many(pool_name, keys_fields_values, ttl, opts \\ []), to: Redis.Hash
   defdelegate hash_delete(pool_name, key, field, opts \\ []), to: Redis.Hash
   defdelegate hash_values(pool_name, key, opts \\ []), to: Redis.Hash
 

--- a/lib/cache/redis/global.ex
+++ b/lib/cache/redis/global.ex
@@ -3,6 +3,8 @@ defmodule Cache.Redis.Global do
   Contains General functions for interfacing with redis
   """
 
+  @default_scan_count 10
+
   def cache_key(pool_name, key) do
     "#{pool_name}:#{key}"
   end
@@ -31,6 +33,48 @@ defmodule Cache.Redis.Global do
     end)
   end
 
+  def scan(pool_name, scan_opts, _opts) do
+    match = scan_opts[:match] || "*"
+    count = scan_opts[:count] || @default_scan_count
+    type = scan_opts[:type]
+
+    with {:ok, elements} <- scan_and_paginate(pool_name, "SCAN", nil, 0, match, count, type) do
+      keys = Enum.map(elements, &String.replace_leading(&1, "#{pool_name}:", ""))
+      {:ok, keys}
+    end
+  end
+  defp scan_and_paginate(acc \\ [], pool_name, operation, key, cursor, match, count, type) do
+    with {:ok, data} <-
+           command(
+             pool_name,
+             redis_scan_command(pool_name, operation, key, cursor, match, count, type)
+           ) do
+      case data do
+        ["0", elements] ->
+          {:ok, acc ++ elements}
+
+        [cursor, elements] ->
+          scan_and_paginate(
+            acc ++ elements,
+            pool_name,
+            operation,
+            key,
+            cursor,
+            match,
+            count,
+            type
+          )
+      end
+    end
+  end
+
+  defp redis_scan_command(pool_name, "SCAN", _key, cursor, match, count, nil) do
+    ["SCAN", cursor, "MATCH", "#{pool_name}:#{match}", "COUNT", count]
+  end
+
+  defp redis_scan_command(pool_name, "SCAN", _key, cursor, match, count, type) do
+    ["SCAN", cursor, "MATCH", "#{pool_name}:#{match}", "COUNT", count, "TYPE", type]
+  end
   defp handle_response({:ok, "OK"}), do: :ok
   defp handle_response({:ok, _} = res), do: res
   defp handle_response({:error, %Redix.ConnectionError{reason: reason}}) do

--- a/lib/cache/sandbox.ex
+++ b/lib/cache/sandbox.ex
@@ -48,12 +48,6 @@ defmodule Cache.Sandbox do
     end)
   end
 
-  def scan(cache_name, _scan_opts, _opts \\ []) do
-    Agent.get(cache_name, fn state ->
-      Map.keys(state)
-    end)
-  end
-
   def hash_delete(cache_name, key, hash_key, _opts) do
     Agent.update(cache_name, fn state ->
       Map.update(state, key, %{}, &Map.delete(&1, hash_key))
@@ -115,6 +109,14 @@ defmodule Cache.Sandbox do
   end
 
   def command!(_cache_name, _command, _opts) do
+    raise "Not Implemented"
+  end
+
+  def scan(_cache_name, _scan_opts, _opts \\ []) do
+    raise "Not Implemented"
+  end
+
+  def hash_scan(_cache_name, _key, _scan_opts, _opts \\ []) do
     raise "Not Implemented"
   end
 end

--- a/lib/cache/sandbox.ex
+++ b/lib/cache/sandbox.ex
@@ -139,11 +139,11 @@ defmodule Cache.Sandbox do
     raise "Not Implemented"
   end
 
-  def scan(_cache_name, _scan_opts, _opts \\ []) do
+  def scan(_cache_name, _scan_opts, _opts) do
     raise "Not Implemented"
   end
 
-  def hash_scan(_cache_name, _key, _scan_opts, _opts \\ []) do
+  def hash_scan(_cache_name, _key, _scan_opts, _opts) do
     raise "Not Implemented"
   end
 end

--- a/lib/cache/sandbox.ex
+++ b/lib/cache/sandbox.ex
@@ -66,6 +66,18 @@ defmodule Cache.Sandbox do
     end)
   end
 
+  def hash_get_many(cache_name, key_fields, _opts) do
+    Agent.get(cache_name, fn state ->
+      values =
+        Enum.reduce(key_fields, [], fn {key, fields}, acc ->
+          values = Enum.map(fields, &state[key][&1])
+          acc ++ [values]
+        end)
+
+      {:ok, values}
+    end)
+  end
+
   def hash_values(cache_name, key, _opts) do
     Agent.get(cache_name, fn state ->
       {:ok, Map.values(state[key] || %{})}

--- a/lib/cache/sandbox.ex
+++ b/lib/cache/sandbox.ex
@@ -48,6 +48,12 @@ defmodule Cache.Sandbox do
     end)
   end
 
+  def scan(cache_name, _scan_opts, _opts \\ []) do
+    Agent.get(cache_name, fn state ->
+      Map.keys(state)
+    end)
+  end
+
   def hash_delete(cache_name, key, hash_key, _opts) do
     Agent.update(cache_name, fn state ->
       Map.update(state, key, %{}, &Map.delete(&1, hash_key))

--- a/lib/cache/sandbox.ex
+++ b/lib/cache/sandbox.ex
@@ -84,7 +84,7 @@ defmodule Cache.Sandbox do
     end)
   end
 
-  def hash_set(cache_name, key, hash_key, value, _opts) do
+  def hash_set(cache_name, key, hash_key, value, nil, _opts) do
     Agent.update(cache_name, fn state ->
       Map.update(state, key, %{hash_key => value}, &Map.put(&1, hash_key, value))
     end)

--- a/lib/cache/sandbox.ex
+++ b/lib/cache/sandbox.ex
@@ -66,10 +66,10 @@ defmodule Cache.Sandbox do
     end)
   end
 
-  def hash_get_many(cache_name, key_fields, _opts) do
+  def hash_get_many(cache_name, keys_fields, _opts) do
     Agent.get(cache_name, fn state ->
       values =
-        Enum.reduce(key_fields, [], fn {key, fields}, acc ->
+        Enum.reduce(keys_fields, [], fn {key, fields}, acc ->
           values = Enum.map(fields, &state[key][&1])
           acc ++ [values]
         end)

--- a/test/cache/redis_test.exs
+++ b/test/cache/redis_test.exs
@@ -34,6 +34,37 @@ defmodule Cache.RedisTest do
     :ok
   end
 
+  describe "&scan/1" do
+    setup %{test: test} do
+      Enum.each(1..100, fn idx ->
+        RedisCache.put(test_key(test, "key_#{idx}"), idx)
+      end)
+    end
+
+    test "accepts a match opt", %{test: test} do
+      scan_opts = [match: "#{test}:key_1*"]
+      assert {:ok, elements} = RedisCache.scan(scan_opts)
+      assert length(elements) === 12
+    end
+
+    test "accepts a count opt", %{test: test} do
+      scan_opts = [match: "#{test}:*", count: 100]
+      assert {:ok, elements} = RedisCache.scan(scan_opts)
+      assert length(elements) === 100
+    end
+
+    test "accepts a type arg", %{test: test} do
+      scan_opts = [match: "#{test}:key_1*", type: "zset"]
+      assert {:ok, elements} = RedisCache.scan(scan_opts)
+      assert Enum.empty?(elements)
+    end
+
+    test "returns all keys in the cache" do
+      assert {:ok, elements} = RedisCache.scan()
+      assert length(elements) >= 100
+    end
+  end
+
   describe "&hash_set/3" do
     test "encodes fields and values in a hash as binaries", %{test: test} do
       test_key = test_key(test, "key")

--- a/test/cache/redis_test.exs
+++ b/test/cache/redis_test.exs
@@ -124,6 +124,13 @@ defmodule Cache.RedisTest do
     end
   end
 
+  describe "&hash_set/4" do
+    test "sets a field and updates key with a ttl", %{test: test} do
+      test_key = test_key(test, "key")
+      {:ok, [1, 1]} = RedisCache.hash_set(test_key, :field, "value", 1)
+    end
+  end
+
   describe "&hash_get/2" do
     setup :put_hash
 
@@ -152,16 +159,25 @@ defmodule Cache.RedisTest do
     end
   end
 
-  describe "&hash_set_many/1" do
-    test "sets many keys", %{test: test} do
+  describe "&hash_set_many/1 and &hash_set_many/2" do
+    setup %{test: test} do
       test_key_1 = test_key(test, "1")
       test_key_2 = test_key(test, "2")
 
       set_1 = {test_key_1, @hash_field_vals}
       set_2 = {test_key_2, @atom_hash_field_vals}
 
-      {:ok, [2]} = RedisCache.hash_set_many([set_1])
-      {:ok, [0, 2]} = RedisCache.hash_set_many([set_1, set_2])
+      {:ok, set_1: set_1, set_2: set_2}
+    end
+
+    test "sets many keys", %{set_1: set_1, set_2: set_2} do
+      assert {:ok, [2]} = RedisCache.hash_set_many([set_1])
+      assert {:ok, [0, 2]} = RedisCache.hash_set_many([set_1, set_2])
+    end
+
+    test "sets many keys with expiries", %{set_1: set_1, set_2: set_2} do
+      assert {:ok, [2, 1]} = RedisCache.hash_set_many([set_1], 1)
+      assert {:ok, [0, 2, 1, 1]} = RedisCache.hash_set_many([set_1, set_2], 1)
     end
   end
 

--- a/test/cache_test.exs
+++ b/test/cache_test.exs
@@ -59,7 +59,7 @@ defmodule CacheTest do
         assert {:ok, value} === cache_module.get(test_key)
       end
 
-      test "deleteing from cache works" do
+      test "deleting from cache works" do
         test_key = "#{Faker.Pokemon.name()}_#{Enum.random(1..100_000_000_000)}"
         value = %{some_value: Faker.App.name()}
         cache_module = unquote(adapter)


### PR DESCRIPTION
- Adds HMGET to redis adapter `&hash_get_many/1`
- Adds SCAN/HSCAN to redis adapter via `&scan/1` and `&hash_scan/2`
- Makes encoding of hash fields optional so as to allow for matching in a HSCAN when keys are strings; non-binary keys may still be used but field matching will not work
- Allows for a TTL option on `&hash_set` via PIPELINE