### PR TITLE
update sandbox hash_set_many behaviour to be consistent

### DIFF
--- a/lib/cache/sandbox.ex
+++ b/lib/cache/sandbox.ex
@@ -111,7 +111,7 @@ defmodule Cache.Sandbox do
 
     if ttl do
       command_resps =
-        Enum.map(keys_fields_values, fn {_, fields_values} -> length(fields_values) end)
+        Enum.map(keys_fields_values, fn {_, fields_values} -> enum_length(fields_values) end)
 
       expiry_resps = Enum.map(keys_fields_values, fn _ -> 1 end)
       {:ok, command_resps ++ expiry_resps}
@@ -268,4 +268,7 @@ defmodule Cache.Sandbox do
         end
       end)
   end
+
+  defp enum_length(m) when is_map(m), do: m |> Map.to_list() |> enum_length()
+  defp enum_length(l), do: length(l)
 end

--- a/test/cache_sandbox_test.exs
+++ b/test/cache_sandbox_test.exs
@@ -26,7 +26,6 @@ defmodule CacheSandboxTest do
     :ok = TestCache.json_set(json_test_key, @json_test_value)
 
     %{key: json_test_key}
-
   end
 
   describe "sandboxing caches" do
@@ -112,6 +111,22 @@ end
       assert :ok = TestCache.json_set(key, ["."], "some value")
       assert {:ok, "some value"} === TestCache.json_get(key)
       assert {:ok, "some value"} === TestCache.json_get(key, ["."])
+    end
+  end
+
+  describe "&hash_set_many/2" do
+    test "returns ok tuple when ttl is passed", %{key: key} do
+      assert {:ok, [1, 1]} = TestCache.hash_set_many([{key, [{"some_key", "some_value"}]}], 1_000)
+    end
+
+    test "returns ok atom when ttl is not passed", %{key: key} do
+      assert :ok = TestCache.hash_set_many([{key, [{"some_key", "some_value"}]}])
+    end
+
+    test "accepts map and list values", %{key: key} do
+      assert {:ok, [1, 1]} = TestCache.hash_set_many([{key, [{"some_key", "some_value"}]}], 1_000)
+
+      assert {:ok, [1, 1]} = TestCache.hash_set_many([{key, %{"some_key" => "some_value"}}], 1_000)
     end
   end
 end

--- a/test/cache_sandbox_test.exs
+++ b/test/cache_sandbox_test.exs
@@ -127,6 +127,10 @@ end
       assert {:ok, [1, 1]} = TestCache.hash_set_many([{key, [{"some_key", "some_value"}]}], 1_000)
 
       assert {:ok, [1, 1]} = TestCache.hash_set_many([{key, %{"some_key" => "some_value"}}], 1_000)
+
+      assert {:ok, [1, 1]} = TestCache.hash_set_many(%{key => [{"some_key", "some_value"}]}, 1_000)
+
+      assert {:ok, [1, 1]} = TestCache.hash_set_many(%{key => %{"some_key" => "some_value"}}, 1_000)
     end
   end
 end


### PR DESCRIPTION
### Current Behaviour

The behaviour of `hash_set_many` is different during tests and raises the error `** (ArgumentError) errors were found at the given arguments: * 1st argument: not a list` when the values being passed is not a list.

### Expected Behaviour

When `hash_set_many`  is passed a `map` or `list` the behaviour is the same as long as the enum has key/value pairs.

### How to reproduce

Create a cache and set many values using a map during `dev` environment

```elixir
defmodule MockCache do
  @moduledoc false
  use Cache,
    adapter: Cache.Redis,
    name: :mock_cache,
    sandbox?: Mix.env() === :test,
    opts: [uri: "redis://localhost:6379"]
end
```

This works when the redis cache is being used since its being automatically converted to a list here https://github.com/MikaAK/elixir_cache/blob/19aa0b0bc5bae0331aff7661ac78f3b2bef26187/lib/cache/redis/hash.ex#L93

```elixir
MockCache.hash_set_many(%{1 => %{"key" => "some state"}}, ttl)/
{:ok, [1, 1]}
```

Create a test and re-run the command and it fails because the sandbox assumes its a list here `https://github.com/MikaAK/elixir_cache/blob/19aa0b0bc5bae0331aff7661ac78f3b2bef26187/lib/cache/sandbox.ex#L114`