### PR TITLE
fix(con cache): allow concache to accept ets options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.13
+- fix: allow `Cache.ConCache` to accept `ets_options` (strict NimbleOptions validation + normalization)
+- feat: allow `Cache.ETS` `write_concurrency: :auto` (OTP 25+)
+
 # 0.3.12
 - chore: fix warnings
 

--- a/lib/cache/con_cache.ex
+++ b/lib/cache/con_cache.ex
@@ -38,7 +38,7 @@ defmodule Cache.ConCache do
           :named_table
           | :compressed
           | {:heir, pid()}
-          | {:write_concurrency, boolean()}
+          | {:write_concurrency, boolean() | :auto}
           | {:read_concurrency, boolean()}
           | :ordered_set
           | :set

--- a/lib/cache/sandbox.ex
+++ b/lib/cache/sandbox.ex
@@ -274,9 +274,7 @@ defmodule Cache.Sandbox do
     end)
   end
 
-  def insert_raw(cache_name, data) when is_tuple(data) do
-    {key, value} = data
-
+  def insert_raw(cache_name, {key, value}) do
     Agent.update(cache_name, fn state ->
       Map.put(state, key, value)
     end)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ElixirCache.MixProject do
   def project do
     [
       app: :elixir_cache,
-      version: "0.3.12",
+      version: "0.3.13",
       elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       description:

--- a/test/cache/con_cache_test.exs
+++ b/test/cache/con_cache_test.exs
@@ -5,6 +5,39 @@ defmodule Cache.ConCacheTest do
   """
   use ExUnit.Case, async: true
 
+  describe "ets_options validation" do
+    test "accepts ets_options keyword list" do
+      validated =
+        NimbleOptions.validate!(
+          [ets_options: [read_concurrency: true, write_concurrency: :auto]],
+          Cache.ConCache.opts_definition()
+        )
+
+      assert [
+               {:read_concurrency, true},
+               {:write_concurrency, :auto}
+             ] = validated[:ets_options]
+    end
+
+    test "rejects unknown ets_options keys" do
+      assert_raise NimbleOptions.ValidationError, fn ->
+        NimbleOptions.validate!(
+          [ets_options: [read_concurency: true]],
+          Cache.ConCache.opts_definition()
+        )
+      end
+    end
+
+    test "rejects invalid ets_options value types" do
+      assert_raise NimbleOptions.ValidationError, fn ->
+        NimbleOptions.validate!(
+          [ets_options: [read_concurrency: :yes]],
+          Cache.ConCache.opts_definition()
+        )
+      end
+    end
+  end
+
   defmodule ConCacheAdapter do
     use Cache,
       adapter: Cache.ConCache,


### PR DESCRIPTION
Cache.ConCache exposes an ets_options config hook, but providing ets_options caused a compile-time failure during use Cache option validation (Cache.ETS.opts_definition/1 missing). This prevented callers from enabling ETS flags like read_concurrency / write_concurrency on ConCache tables.

PR also adds support for the [`:auto` ](https://www.erlang.org/doc/apps/stdlib/ets.html#new/2)option on ETS table `write_concurrency` 

```bash
Compiling 17 files (.ex)

== Compilation error in file lib/schema_cache/firestore/con_cache.ex ==
** (UndefinedFunctionError) function Cache.ETS.opts_definition/1 is undefined or private. Did you mean:

      * opts_definition/0

    (elixir_cache 0.3.12) Cache.ETS.opts_definition([read_concurrency: true, write_concurrency: false])
    (nimble_options 1.1.1) lib/nimble_options.ex:797: NimbleOptions.validate_type/3
    (nimble_options 1.1.1) lib/nimble_options.ex:562: NimbleOptions.validate_option/3
    (nimble_options 1.1.1) lib/nimble_options.ex:542: NimbleOptions.reduce_options/2
    (elixir 1.18.4) lib/enum.ex:4968: Enumerable.List.reduce/3
    (elixir 1.18.4) lib/enum.ex:2600: Enum.reduce_while/3
    (nimble_options 1.1.1) lib/nimble_options.ex:535: NimbleOptions.validate_options/2
    (nimble_options 1.1.1) lib/nimble_options.ex:508: NimbleOptions.validate_options_with_schema_and_path/3
    ```