### PR TITLE
fix(ets): route ETS-specific functions through sandbox adapter

### DIFF
--- a/lib/cache.ex
+++ b/lib/cache.ex
@@ -95,6 +95,64 @@ defmodule Cache do
         use unquote(opts[:adapter])
       end
 
+      if unquote(opts[:sandbox?]) == true and unquote(opts[:adapter]) === Cache.ETS do
+        defoverridable update_counter: 2,
+                       update_counter: 3,
+                       insert_raw: 1,
+                       match_object: 1,
+                       match_object: 2
+
+        def update_counter(key, update_op) do
+          key = maybe_sandbox_key(key)
+          @cache_adapter.update_counter(@cache_name, key, update_op)
+        end
+
+        def update_counter(key, update_op, default) do
+          key = maybe_sandbox_key(key)
+          @cache_adapter.update_counter(@cache_name, key, update_op, default)
+        end
+
+        def insert_raw(data) when is_tuple(data) do
+          key = maybe_sandbox_key(elem(data, 0))
+
+          data =
+            if tuple_size(data) === 2 do
+              {key, elem(data, 1)}
+            else
+              put_elem(data, 0, key)
+            end
+
+          @cache_adapter.insert_raw(@cache_name, data)
+        end
+
+        def insert_raw(data) when is_list(data) do
+          data =
+            Enum.map(data, fn tuple ->
+              key = maybe_sandbox_key(elem(tuple, 0))
+
+              if tuple_size(tuple) === 2 do
+                {key, elem(tuple, 1)}
+              else
+                put_elem(tuple, 0, key)
+              end
+            end)
+
+          @cache_adapter.insert_raw(@cache_name, data)
+        end
+
+        def match_object(pattern) when is_tuple(pattern) do
+          @cache_adapter.match_object(@cache_name, pattern)
+        end
+
+        def match_object(continuation) when not is_tuple(continuation) do
+          @cache_adapter.match_object(@cache_name, continuation)
+        end
+
+        def match_object(pattern, limit) do
+          @cache_adapter.match_object(@cache_name, pattern, limit)
+        end
+      end
+
       def cache_name, do: @cache_name
       def cache_adapter, do: @cache_adapter
 

--- a/test/cache/ets_sandbox_test.exs
+++ b/test/cache/ets_sandbox_test.exs
@@ -1,0 +1,99 @@
+defmodule Cache.ETSSandboxTest do
+  use ExUnit.Case, async: true
+
+  defmodule TestETSSandboxCache do
+    use Cache,
+      adapter: Cache.ETS,
+      name: :test_ets_sandbox_cache,
+      opts: [],
+      sandbox?: Mix.env() === :test
+  end
+
+  setup do
+    Cache.SandboxRegistry.start(TestETSSandboxCache)
+
+    :ok
+  end
+
+  describe "update_counter/2 sandbox isolation" do
+    test "update_counter works through sandbox adapter" do
+      TestETSSandboxCache.put("counter_key", 0)
+
+      result = TestETSSandboxCache.update_counter("counter_key", 1)
+      assert result === 1
+
+      result = TestETSSandboxCache.update_counter("counter_key", 5)
+      assert result === 6
+    end
+
+    test "update_counter is isolated between tests" do
+      assert {:ok, nil} = TestETSSandboxCache.get("counter_key")
+    end
+  end
+
+  describe "update_counter/3 sandbox isolation" do
+    test "update_counter with default works through sandbox adapter" do
+      result = TestETSSandboxCache.update_counter("new_counter", 1, {"new_counter", 10})
+      assert result === 11
+    end
+
+    test "update_counter with default is isolated between tests" do
+      assert {:ok, nil} = TestETSSandboxCache.get("new_counter")
+    end
+  end
+
+  describe "insert_raw/1 sandbox isolation" do
+    test "insert_raw with tuple works through sandbox adapter" do
+      assert true = TestETSSandboxCache.insert_raw({"raw_key", "raw_value"})
+
+      result = TestETSSandboxCache.match_object({:_, "raw_value"})
+      assert length(result) === 1
+    end
+
+    test "insert_raw with list works through sandbox adapter" do
+      assert true = TestETSSandboxCache.insert_raw([{"list_key1", "val1"}, {"list_key2", "val2"}])
+
+      result = TestETSSandboxCache.match_object({:_, "val1"})
+      assert length(result) === 1
+
+      result = TestETSSandboxCache.match_object({:_, "val2"})
+      assert length(result) === 1
+    end
+
+    test "insert_raw is isolated between tests" do
+      assert [] = TestETSSandboxCache.match_object({:_, "raw_value"})
+      assert [] = TestETSSandboxCache.match_object({:_, "val1"})
+    end
+  end
+
+  describe "match_object/1 sandbox isolation" do
+    test "match_object works through sandbox adapter" do
+      TestETSSandboxCache.insert_raw({"mo_key1", "value1"})
+      TestETSSandboxCache.insert_raw({"mo_key2", "value2"})
+
+      result = TestETSSandboxCache.match_object({:_, "value1"})
+      assert length(result) === 1
+    end
+
+    test "match_object is isolated between tests" do
+      result = TestETSSandboxCache.match_object({:_, "value1"})
+      assert result === []
+    end
+  end
+
+  describe "match_object/2 sandbox isolation" do
+    test "match_object with limit works through sandbox adapter" do
+      TestETSSandboxCache.insert_raw({"mol_key1", "same_value"})
+      TestETSSandboxCache.insert_raw({"mol_key2", "same_value"})
+      TestETSSandboxCache.insert_raw({"mol_key3", "same_value"})
+
+      {result, :end_of_table} = TestETSSandboxCache.match_object({:_, "same_value"}, 2)
+      assert length(result) === 2
+    end
+
+    test "match_object with limit is isolated between tests" do
+      result = TestETSSandboxCache.match_object({:_, "same_value"})
+      assert result === []
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- ETS-specific functions (`update_counter/2`, `update_counter/3`, `insert_raw/1`, `match_object/1`, `match_object/2`) were bypassing sandbox isolation by calling `:ets` directly instead of routing through `@cache_adapter`
- Added `defoverridable` wrappers in the `__using__` macro (`lib/cache.ex`) that prefix keys via `maybe_sandbox_key` and dispatch through `@cache_adapter` when `sandbox?: true` and `adapter: Cache.ETS`
- The sandbox adapter (`Cache.Sandbox`) already had implementations for these functions — they just were never called from the generated module
