### PR TITLE
Obscure error messages in metrics

### DIFF
--- a/lib/cache/metrics.ex
+++ b/lib/cache/metrics.ex
@@ -96,9 +96,8 @@ if Application.ensure_loaded(:prometheus_telemetry) === :ok do
       metadata
       |> Map.take([:error, :cache_name])
       |> Map.update(:error, "unknown", fn
-        %ErrorMessage{code: code, message: error} -> "#{code}: #{error}"
+        %ErrorMessage{code: code} -> code
         reason when is_atom(reason) -> to_string(reason)
-        reason when is_binary(reason) -> reason
         _ -> "unknown"
       end)
     end


### PR DESCRIPTION
Fixes raw error messages appearing in metrics parameters, which caused problems when the error message could be lengthy and unique resulting in significant slowdown and growth of the metrics export.