### PR TITLE
chore(metrics): fixed cardinality leak on extract_error_metadata/1

### DIFF
--- a/lib/cache/metrics.ex
+++ b/lib/cache/metrics.ex
@@ -96,7 +96,7 @@ if Application.ensure_loaded(:prometheus_telemetry) === :ok do
       metadata
       |> Map.take([:error, :cache_name])
       |> Map.update(:error, "unknown", fn
-        %ErrorMessage{code: code, message: error} -> "#{code}: #{error}"
+        %ErrorMessage{code: code} -> code
         reason when is_atom(reason) -> to_string(reason)
         reason when is_binary(reason) -> reason
         _ -> "unknown"


### PR DESCRIPTION
This was observed as negatively impacting our prom scrape this morning. 