### PR TITLE
fix(sandbox): match real ETS match-spec semantics via :ets primitives

### DIFF
--- a/lib/cache/sandbox.ex
+++ b/lib/cache/sandbox.ex
@@ -801,157 +801,98 @@ defmodule Cache.Sandbox do
 
   defp extract_bindings(_object, _pattern), do: []
 
+  # Match specs are compiled and run via :ets primitives so sandbox semantics
+  # match real ETS (body tuple handling, guard evaluation, malformed-spec errors).
+  # `:ets.match_spec_compile/1` raises `ArgumentError` on invalid specs in the
+  # caller process; `:ets.match_spec_run/2` evaluates guards and body terms with
+  # full ETS semantics against the per-sandbox sub-map. Continuations are not
+  # implemented — `select/3` returns `{results, :end_of_table}` unconditionally,
+  # so callers cannot resume via `select/1`.
   def select(cache_name, match_spec) do
+    compiled = :ets.match_spec_compile(match_spec)
+
     scoped_agent_get(cache_name, fn sub ->
-      sub
-      |> Map.to_list()
-      |> Enum.flat_map(fn {key, value} -> apply_match_spec({key, value}, match_spec) end)
+      sub |> Map.to_list() |> :ets.match_spec_run(compiled)
     end)
   end
 
   def select(cache_name, match_spec, limit) do
+    compiled = :ets.match_spec_compile(match_spec)
+
     scoped_agent_get(cache_name, fn sub ->
       results =
         sub
         |> Map.to_list()
-        |> Enum.flat_map(fn {key, value} -> apply_match_spec({key, value}, match_spec) end)
+        |> :ets.match_spec_run(compiled)
         |> Enum.take(limit)
 
       {results, :end_of_table}
     end)
   end
 
-  defp apply_match_spec(object, match_spec) when is_list(match_spec) do
-    Enum.flat_map(match_spec, fn spec -> apply_single_match_spec(object, spec) end)
-  end
-
-  # NOTE: Guards are not evaluated in the sandbox. Implementing a full guard
-  # interpreter for match specs is non-trivial and unlikely to be needed in
-  # typical test scenarios. If you rely on guards in match specs, consider
-  # testing against the real adapter.
-  defp apply_single_match_spec(object, {pattern, _guards, result_spec}) do
-    if match_pattern?(object, pattern) do
-      bindings = extract_numbered_bindings(object, pattern)
-      [transform_result(object, result_spec, bindings)]
-    else
-      []
-    end
-  end
-
-  defp apply_single_match_spec(_object, _spec), do: []
-
-  defp extract_numbered_bindings(object, pattern)
-       when is_tuple(pattern) and is_tuple(object) do
-    object_list = Tuple.to_list(object)
-    pattern_list = Tuple.to_list(pattern)
-
-    object_list
-    |> Enum.zip(pattern_list)
-    |> Enum.reduce(%{}, fn {obj_elem, pat_elem}, acc ->
-      case parse_binding_number(pat_elem) do
-        nil -> acc
-        n -> Map.put(acc, n, obj_elem)
-      end
-    end)
-  end
-
-  defp extract_numbered_bindings(_object, _pattern), do: %{}
-
-  defp parse_binding_number(atom) when is_atom(atom) do
-    case Atom.to_string(atom) do
-      "$" <> rest ->
-        case Integer.parse(rest) do
-          {n, ""} -> n
-          _ -> nil
-        end
-
-      _ ->
-        nil
-    end
-  end
-
-  defp parse_binding_number(_), do: nil
-
-  defp transform_result(object, [:"$_"], _bindings), do: object
-
-  defp transform_result(_object, [:"$$"], bindings) do
-    bindings
-    |> Enum.sort_by(&elem(&1, 0))
-    |> Enum.map(&elem(&1, 1))
-  end
-
-  defp transform_result(_object, [result], bindings) do
-    resolve_bindings(result, bindings)
-  end
-
-  defp transform_result(_object, result, _bindings), do: result
-
-  defp resolve_bindings(atom, bindings) when is_atom(atom) do
-    case parse_binding_number(atom) do
-      nil -> atom
-      n -> Map.get(bindings, n, atom)
-    end
-  end
-
-  defp resolve_bindings(tuple, bindings) when is_tuple(tuple) do
-    tuple
-    |> Tuple.to_list()
-    |> Enum.map(&resolve_bindings(&1, bindings))
-    |> List.to_tuple()
-  end
-
-  defp resolve_bindings(list, bindings) when is_list(list) do
-    Enum.map(list, &resolve_bindings(&1, bindings))
-  end
-
-  defp resolve_bindings(value, _bindings), do: value
-
   def select_count(cache_name, match_spec) do
+    compiled = :ets.match_spec_compile(match_spec)
+
     scoped_agent_get(cache_name, fn sub ->
       sub
       |> Map.to_list()
-      |> Enum.count(fn {key, value} ->
-        result = apply_match_spec({key, value}, match_spec)
-        result !== [] and hd(result) === true
-      end)
+      |> :ets.match_spec_run(compiled)
+      |> Enum.count(&(&1 === true))
     end)
   end
 
   def select_delete(cache_name, match_spec) do
+    compiled = :ets.match_spec_compile(match_spec)
+
     scoped_agent_get_and_update(cache_name, fn sub ->
       {to_delete, to_keep} =
         sub
         |> Map.to_list()
-        |> Enum.split_with(fn {key, value} ->
-          result = apply_match_spec({key, value}, match_spec)
-          result !== [] and hd(result) === true
+        |> Enum.split_with(fn obj ->
+          [obj] |> :ets.match_spec_run(compiled) |> Enum.any?(&(&1 === true))
         end)
 
       {length(to_delete), Map.new(to_keep)}
     end)
   end
 
+  # select_replace splits the read and update across two Agent calls so the
+  # key-change ArgumentError raises in the caller's process. Raising inside a
+  # scoped_agent_get_and_update callback would crash the Agent and surface as
+  # an {:exit, ...} instead of ArgumentError. Non-atomic read-modify-write is
+  # acceptable for sandbox/test use where there's one caller per sandbox_id.
   def select_replace(cache_name, match_spec) do
-    scoped_agent_get_and_update(cache_name, fn sub ->
-      {count, new_sub} =
-        sub
-        |> Map.to_list()
-        |> Enum.reduce({0, sub}, fn {key, value}, {cnt, acc} ->
-          result = apply_match_spec({key, value}, match_spec)
+    compiled = :ets.match_spec_compile(match_spec)
+    entries = scoped_agent_get(cache_name, &Map.to_list/1)
 
-          case result do
-            [new_obj] when is_tuple(new_obj) ->
-              new_key = elem(new_obj, 0)
-              new_value = if tuple_size(new_obj) === 2, do: elem(new_obj, 1), else: new_obj
-              {cnt + 1, acc |> Map.delete(key) |> Map.put(new_key, new_value)}
+    updates =
+      Enum.flat_map(entries, fn {key, _value} = obj ->
+        case :ets.match_spec_run([obj], compiled) do
+          [new_obj] when is_tuple(new_obj) and tuple_size(new_obj) >= 1 ->
+            new_key = elem(new_obj, 0)
 
-            _ ->
-              {cnt, acc}
-          end
-        end)
+            if new_key !== key do
+              raise ArgumentError,
+                    "select_replace cannot change the key of an object"
+            end
 
-      {count, new_sub}
-    end)
+            new_value =
+              if tuple_size(new_obj) === 2, do: elem(new_obj, 1), else: new_obj
+
+            [{key, new_value}]
+
+          _ ->
+            []
+        end
+      end)
+
+    if updates !== [] do
+      scoped_agent_update(cache_name, fn sub ->
+        Enum.reduce(updates, sub, fn {k, v}, acc -> Map.put(acc, k, v) end)
+      end)
+    end
+
+    length(updates)
   end
 
   def match_delete(cache_name, pattern) do

--- a/test/cache/ets_sandbox_test.exs
+++ b/test/cache/ets_sandbox_test.exs
@@ -12,8 +12,21 @@ defmodule Cache.ETSSandboxTest do
   setup do
     Cache.SandboxRegistry.start(TestETSSandboxCache)
 
-    :ok
+    ets_table =
+      :ets.new(:"ets_match_spec_#{:erlang.unique_integer([:positive])}", [:set, :public])
+
+    %{ets: ets_table}
   end
+
+  defp load(ets, objects) do
+    Enum.each(objects, fn {_k, _v} = obj ->
+      TestETSSandboxCache.insert_raw(obj)
+      :ets.insert(ets, obj)
+    end)
+  end
+
+  defp sort_results(list) when is_list(list), do: Enum.sort(list)
+  defp sort_results(other), do: other
 
   describe "update_counter/2 sandbox isolation" do
     test "update_counter works through sandbox adapter" do
@@ -94,6 +107,170 @@ defmodule Cache.ETSSandboxTest do
     test "match_object with limit is isolated between tests" do
       result = TestETSSandboxCache.match_object({:_, "same_value"})
       assert result === []
+    end
+  end
+
+  describe "select/2 match-spec parity with :ets.select/2" do
+    test "returns the whole object via $_", %{ets: ets} do
+      load(ets, [{"a", 1}, {"b", 2}])
+
+      spec = [{:"$1", [], [:"$_"]}]
+
+      assert sort_results(TestETSSandboxCache.select(spec)) ===
+               sort_results(:ets.select(ets, spec))
+    end
+
+    test "returns bindings list via $$", %{ets: ets} do
+      load(ets, [{"a", 1}, {"b", 2}])
+
+      spec = [{{:"$1", :"$2"}, [], [:"$$"]}]
+
+      assert sort_results(TestETSSandboxCache.select(spec)) ===
+               sort_results(:ets.select(ets, spec))
+    end
+
+    test "double-wrapped body tuple constructs a tuple (idiomatic form)", %{ets: ets} do
+      load(ets, [{"a", 1}, {"b", 2}])
+
+      spec = [{{:"$1", :"$2"}, [], [{{:"$1", :"$2"}}]}]
+
+      sandbox = TestETSSandboxCache.select(spec)
+      ets_result = :ets.select(ets, spec)
+
+      assert sort_results(sandbox) === sort_results(ets_result)
+
+      Enum.each(sandbox, fn result ->
+        assert is_tuple(result)
+        assert tuple_size(result) === 2
+      end)
+    end
+
+    test "single-wrapped body tuple raises ArgumentError" do
+      spec = [{{:"$1", :"$2"}, [], [{:"$1", :"$2"}]}]
+
+      assert_raise ArgumentError, fn -> TestETSSandboxCache.select(spec) end
+    end
+
+    test "invalid match spec raises ArgumentError" do
+      assert_raise ArgumentError, fn -> TestETSSandboxCache.select([:not_a_valid_spec]) end
+    end
+
+    test "literal term in body is returned as-is", %{ets: ets} do
+      load(ets, [{"a", 1}, {"b", 2}])
+
+      spec = [{{:"$1", :"$2"}, [], [:matched]}]
+
+      assert sort_results(TestETSSandboxCache.select(spec)) ===
+               sort_results(:ets.select(ets, spec))
+    end
+
+    test "guards filter results", %{ets: ets} do
+      load(ets, [{"a", 5}, {"b", 15}, {"c", 25}])
+
+      spec = [{{:"$1", :"$2"}, [{:>, :"$2", 10}], [:"$_"]}]
+
+      assert sort_results(TestETSSandboxCache.select(spec)) ===
+               sort_results(:ets.select(ets, spec))
+    end
+
+    test "guards with conjunction (:andalso)", %{ets: ets} do
+      load(ets, [{"a", 5}, {"b", 15}, {"c", 100}])
+
+      spec = [{{:"$1", :"$2"}, [{:andalso, {:>, :"$2", 10}, {:<, :"$2", 50}}], [:"$2"]}]
+
+      assert sort_results(TestETSSandboxCache.select(spec)) ===
+               sort_results(:ets.select(ets, spec))
+    end
+  end
+
+  describe "select/3 sandbox" do
+    test "limit truncates results, returns :end_of_table", %{ets: ets} do
+      load(ets, [{"a", 1}, {"b", 2}, {"c", 3}, {"d", 4}])
+
+      spec = [{:"$1", [], [:"$_"]}]
+
+      {results, cont} = TestETSSandboxCache.select(spec, 2)
+
+      assert length(results) === 2
+      assert cont === :end_of_table
+    end
+  end
+
+  describe "select_count/2 sandbox" do
+    test "counts entries whose body yields true", %{ets: ets} do
+      load(ets, [{"a", 5}, {"b", 15}, {"c", 25}])
+
+      spec = [{{:"$1", :"$2"}, [{:>, :"$2", 10}], [true]}]
+
+      assert TestETSSandboxCache.select_count(spec) === :ets.select_count(ets, spec)
+    end
+
+    test "ignores non-true body results", %{ets: ets} do
+      load(ets, [{"a", 1}, {"b", 2}])
+
+      spec = [{{:"$1", :"$2"}, [], [:"$2"]}]
+
+      assert TestETSSandboxCache.select_count(spec) === :ets.select_count(ets, spec)
+      assert TestETSSandboxCache.select_count(spec) === 0
+    end
+  end
+
+  describe "select_delete/2 sandbox" do
+    test "deletes entries whose body yields true and returns count", %{ets: ets} do
+      load(ets, [{"a", 5}, {"b", 15}, {"c", 25}])
+
+      spec = [{{:"$1", :"$2"}, [{:>, :"$2", 10}], [true]}]
+
+      assert TestETSSandboxCache.select_delete(spec) === :ets.select_delete(ets, spec)
+
+      assert {:ok, 5} = TestETSSandboxCache.get("a")
+      assert {:ok, nil} = TestETSSandboxCache.get("b")
+      assert {:ok, nil} = TestETSSandboxCache.get("c")
+    end
+
+    test "leaves entries when body is not true", %{ets: ets} do
+      load(ets, [{"a", 1}, {"b", 2}])
+
+      spec = [{{:"$1", :"$2"}, [], [:"$2"]}]
+
+      assert TestETSSandboxCache.select_delete(spec) === 0
+      assert {:ok, 1} = TestETSSandboxCache.get("a")
+      assert {:ok, 2} = TestETSSandboxCache.get("b")
+    end
+  end
+
+  describe "select_replace/2 sandbox" do
+    test "replaces matching entries and returns count", %{ets: ets} do
+      load(ets, [{"a", 1}, {"b", 2}])
+
+      spec = [{{:"$1", :"$2"}, [], [{{:"$1", {:+, :"$2", 10}}}]}]
+
+      assert TestETSSandboxCache.select_replace(spec) === :ets.select_replace(ets, spec)
+
+      assert {:ok, 11} = TestETSSandboxCache.get("a")
+      assert {:ok, 12} = TestETSSandboxCache.get("b")
+    end
+
+    test "raises when body tries to change the key", %{ets: ets} do
+      load(ets, [{"a", 1}])
+
+      spec = [{{:"$1", :"$2"}, [], [{{:new_key, :"$2"}}]}]
+
+      assert_raise ArgumentError, fn -> TestETSSandboxCache.select_replace(spec) end
+      assert_raise ArgumentError, fn -> :ets.select_replace(ets, spec) end
+    end
+  end
+
+  describe "select_reverse/2 sandbox" do
+    test "returns select results reversed", %{ets: ets} do
+      load(ets, [{"a", 1}, {"b", 2}])
+
+      spec = [{:"$1", [], [:"$_"]}]
+
+      forward = TestETSSandboxCache.select(spec)
+      reversed = TestETSSandboxCache.select_reverse(spec)
+
+      assert reversed === Enum.reverse(forward)
     end
   end
 end


### PR DESCRIPTION
Swaps the hand-rolled match-spec interpreter in `Cache.Sandbox` for `:ets.match_spec_compile/1` + `:ets.match_spec_run/2` so sandbox semantics match real ETS. I found a bug in my day job: a prod match spec `[{:"$1", :"$2"}]` passed every sandbox test and raised `ArgumentError` on the first prod subscribe. The sandbox was silently treating body tuples as construction. The idiomatic fix `[{{:"$1", :"$2"}}]` was correct in prod but returned the wrong shape in the sandbox, so we ended up with a workaround. This affects `select/2,3`, `select_count/2`, `select_delete/2`, and `select_replace/2`; `select_reverse/*` just delegates, so they're unchanged. Parity tests added to `test/cache/ets_sandbox_test.exs`.

