### PR TITLE
fix: synchronous table startup for ETS/DETS/Counter adapters

### DIFF
--- a/lib/cache/counter.ex
+++ b/lib/cache/counter.ex
@@ -97,15 +97,25 @@ defmodule Cache.Counter do
 
   @impl Cache
   def start_link(opts) do
-    Task.start_link(fn ->
-      cache_name = opts[:table_name]
-      initial_size = opts[:initial_size] || 1
-      counters_opts = if opts[:write_concurrency], do: [:atomics, :write_concurrency], else: [:atomics]
-      ref = :counters.new(initial_size, counters_opts)
-      :persistent_term.put({cache_name, @ref_key}, ref)
-      :persistent_term.put({cache_name, @size_key}, initial_size)
-      Process.hibernate(Function, :identity, [nil])
-    end)
+    parent = self()
+    ready_ref = make_ref()
+
+    {:ok, pid} =
+      Task.start_link(fn ->
+        cache_name = opts[:table_name]
+        initial_size = opts[:initial_size] || 1
+        counters_opts = if opts[:write_concurrency], do: [:atomics, :write_concurrency], else: [:atomics]
+        ref = :counters.new(initial_size, counters_opts)
+        :persistent_term.put({cache_name, @ref_key}, ref)
+        :persistent_term.put({cache_name, @size_key}, initial_size)
+        send(parent, {ready_ref, :ready})
+        Process.hibernate(Function, :identity, [nil])
+      end)
+
+    receive do
+      {^ready_ref, :ready} -> {:ok, pid}
+      {:EXIT, ^pid, reason} -> {:error, reason}
+    end
   end
 
   @impl Cache

--- a/lib/cache/dets.ex
+++ b/lib/cache/dets.ex
@@ -365,25 +365,35 @@ defmodule Cache.DETS do
 
   @impl Cache
   def start_link(opts) do
-    Task.start_link(fn ->
-      table_name = opts[:table_name]
+    parent = self()
+    ref = make_ref()
 
-      file_path =
-        opts[:file_path]
-        |> to_string
-        |> create_file_name(table_name)
-        |> tap(&File.mkdir_p!(Path.dirname(&1)))
-        |> String.to_charlist()
+    {:ok, pid} =
+      Task.start_link(fn ->
+        table_name = opts[:table_name]
 
-      opts =
-        opts
-        |> Keyword.drop([:table_name, :file_path])
-        |> Kernel.++(access: :read_write, file: file_path)
+        file_path =
+          opts[:file_path]
+          |> to_string
+          |> create_file_name(table_name)
+          |> tap(&File.mkdir_p!(Path.dirname(&1)))
+          |> String.to_charlist()
 
-      {:ok, _} = :dets.open_file(table_name, opts)
+        opts =
+          opts
+          |> Keyword.drop([:table_name, :file_path])
+          |> Kernel.++(access: :read_write, file: file_path)
 
-      Process.hibernate(Function, :identity, [nil])
-    end)
+        {:ok, _} = :dets.open_file(table_name, opts)
+
+        send(parent, {ref, :ready})
+        Process.hibernate(Function, :identity, [nil])
+      end)
+
+    receive do
+      {^ref, :ready} -> {:ok, pid}
+      {:EXIT, ^pid, reason} -> {:error, reason}
+    end
   end
 
   defp create_file_name(file_path, table_name) do

--- a/lib/cache/ets.ex
+++ b/lib/cache/ets.ex
@@ -617,30 +617,40 @@ defmodule Cache.ETS do
 
   @impl Cache
   def start_link(opts) do
-    Task.start_link(fn ->
-      table_name = opts[:table_name]
-      rehydration_path = opts[:rehydration_path]
+    parent = self()
+    ref = make_ref()
 
-      ets_opts =
-        opts
-        |> Keyword.drop([:table_name, :type, :rehydration_path])
-        |> Kernel.++([opts[:type], :public, :named_table])
+    {:ok, pid} =
+      Task.start_link(fn ->
+        table_name = opts[:table_name]
+        rehydration_path = opts[:rehydration_path]
 
-      ets_opts =
-        if opts[:compressed] do
-          Keyword.delete(ets_opts, :compressed) ++ [:compressed]
-        else
-          ets_opts
+        ets_opts =
+          opts
+          |> Keyword.drop([:table_name, :type, :rehydration_path])
+          |> Kernel.++([opts[:type], :public, :named_table])
+
+        ets_opts =
+          if opts[:compressed] do
+            Keyword.delete(ets_opts, :compressed) ++ [:compressed]
+          else
+            ets_opts
+          end
+
+        rehydrate_or_create_table(table_name, rehydration_path, ets_opts)
+
+        if rehydration_path do
+          setup_exit_signal_handlers(table_name, rehydration_path)
         end
 
-      rehydrate_or_create_table(table_name, rehydration_path, ets_opts)
+        send(parent, {ref, :ready})
+        Process.hibernate(Function, :identity, [nil])
+      end)
 
-      if rehydration_path do
-        setup_exit_signal_handlers(table_name, rehydration_path)
-      end
-
-      Process.hibernate(Function, :identity, [nil])
-    end)
+    receive do
+      {^ref, :ready} -> {:ok, pid}
+      {:EXIT, ^pid, reason} -> {:error, reason}
+    end
   end
 
   defp rehydrate_or_create_table(table_name, rehydration_path, ets_opts)


### PR DESCRIPTION
## Summary

- `Cache.ETS`, `Cache.DETS`, and `Cache.Counter` all wrapped their setup in `Task.start_link(fn -> ... end)`. The task spawned, `start_link` returned `{:ok, pid}`, and the supervisor moved on — but the table creation/opening was still running inside the task. Callers that hit the cache immediately after the supervisor came up could see a missing table.
- Each adapter's task now sends a `:ready` signal back to the parent after setup completes; `start_link` blocks on that signal (or on `{:EXIT, pid, reason}` if setup crashes), giving the supervisor a genuinely synchronous start.
- `Cache.PersistentTerm` has no setup work, and `Cache.RefreshAhead.start_tracker` already creates its tracker ETS table before `Task.start_link` runs — neither has a race, so both were left alone.

## Test plan

- [x] `mix test test/cache/ets_test.exs test/cache/dets_test.exs test/cache/counter_test.exs` — 85 tests, 0 failures
- [x] `mix credo --strict lib/cache/ets.ex lib/cache/dets.ex lib/cache/counter.ex` — no issues
- [x] Spot-check: a fresh test using `start_supervised!` followed by an immediate `get/put` (no `Process.sleep`) passes against the patched code, confirming the table is ready the moment `start_link` returns.

## Follow-up (not in this PR)

The `Process.sleep(100)` calls scattered across the existing ETS/DETS/Counter tests are now unnecessary and can be removed in a follow-up cleanup.