### PR TITLE
ci: run workflows on pull_request, restrict push to main

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,9 @@
 name: Coverage
 
-on: push
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   Coverage:

--- a/.github/workflows/credo.yml
+++ b/.github/workflows/credo.yml
@@ -1,6 +1,9 @@
 name: Credo
 
-on: push
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   Credo:

--- a/.github/workflows/dialyzer.yml
+++ b/.github/workflows/dialyzer.yml
@@ -1,6 +1,9 @@
 name: Dialyzer
 
-on: push
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   Dialyzer:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test
 
-on: push
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   Test:


### PR DESCRIPTION
## Summary

- All four workflows (`Test`, `Coverage`, `Credo`, `Dialyzer`) used `on: push`, which fires on every branch push **and** on PR sync events — every PR update kicked off two duplicate runs.
- Switched each workflow to:
  ```yaml
  on:
    push:
      branches: [main]
    pull_request:
  ```
  which runs CI once per PR update plus once on `main` after merge (covering post-squash branch protection / status checks).

## Test plan

- [ ] Open this PR — CI should kick off via the `pull_request` trigger and report Test / Coverage / Credo / Dialyzer once each.
- [ ] After merge to `main`, those four checks fire again on `main` via the `push: branches: [main]` trigger.
- [ ] Pushing to a feature branch without an open PR should NOT trigger any workflow runs.