### PR TITLE
perf(sandbox): make register_caches sleep configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Performance
 
-- perf(sandbox): make `Cache.SandboxRegistry.register_caches/2` post-register sleep configurable via `Application.compile_env(:elixir_cache, :sandbox_sleep_ms, 50)`. Default is unchanged (50 ms). Test suites that don't need the sleep can set it to 0 to save ~50 ms per cache registered per test — material on apps with many cache modules.
+- perf(sandbox): make `Cache.SandboxRegistry.register_caches/2` post-register sleep configurable via `Cache.Config.sandbox_sleep_ms/0` (`config :elixir_cache, :sandbox_sleep_ms, 50`). Default is unchanged (50 ms). Test suites that don't need the sleep can set it to `0` in `config/test.exs` to save ~50 ms per cache registered per test — material on apps with many cache modules.
 
 # 0.4.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.4.9
+
+## Performance
+
+- perf(sandbox): make `Cache.SandboxRegistry.register_caches/2` post-register sleep configurable via `Application.compile_env(:elixir_cache, :sandbox_sleep_ms, 50)`. Default is unchanged (50 ms). Test suites that don't need the sleep can set it to 0 to save ~50 ms per cache registered per test — material on apps with many cache modules.
+
 # 0.4.8
 
 ## Bug Fixes

--- a/lib/cache/config.ex
+++ b/lib/cache/config.ex
@@ -1,0 +1,9 @@
+defmodule Cache.Config do
+  @moduledoc false
+
+  @app :elixir_cache
+
+  def sandbox_sleep_ms do
+    Application.get_env(@app, :sandbox_sleep_ms, 50)
+  end
+end

--- a/lib/cache/sandbox_registry.ex
+++ b/lib/cache/sandbox_registry.ex
@@ -5,7 +5,6 @@ defmodule Cache.SandboxRegistry do
   More details soon...
   """
 
-  @sleep_for_sync Application.compile_env(:elixir_cache, :sandbox_sleep_ms, 50)
   @registry :elixir_cache_sandbox
   @keys :duplicate
 
@@ -38,7 +37,7 @@ defmodule Cache.SandboxRegistry do
         {:error, :registry_not_started} -> raise_not_started!()
       end
 
-    Process.sleep(@sleep_for_sync)
+    Process.sleep(Cache.Config.sandbox_sleep_ms())
 
     res
   end

--- a/lib/cache/sandbox_registry.ex
+++ b/lib/cache/sandbox_registry.ex
@@ -5,7 +5,7 @@ defmodule Cache.SandboxRegistry do
   More details soon...
   """
 
-  @sleep_for_sync 50
+  @sleep_for_sync Application.compile_env(:elixir_cache, :sandbox_sleep_ms, 50)
   @registry :elixir_cache_sandbox
   @keys :duplicate
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ElixirCache.MixProject do
   def project do
     [
       app: :elixir_cache,
-      version: "0.4.8",
+      version: "0.4.9",
       elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       description:


### PR DESCRIPTION
## Summary

`Cache.SandboxRegistry.register_caches/2` does `Process.sleep(50)` after each `Registry.register` call to give the entry time to propagate. With N caches registered per test (common in apps with many cache modules), this becomes ~N × 50 ms of fixed overhead per test setup.

This change reads the value via `Application.compile_env(:elixir_cache, :sandbox_sleep_ms, 50)`. Default is unchanged at 50 ms (backward compatible). Test suites that don't need it can opt in to a faster value:

```elixir
# config/test.exs
config :elixir_cache, :sandbox_sleep_ms, 0
```

## Why this is safe

`Registry.register/4` returns `{:ok, _}` synchronously — once it returns, the entry is in the registry. The 50 ms sleep is paranoia for older Registry implementations (or possibly for letting `:duplicate`-keyed registrations propagate visibility). Modern Registry doesn't need it for correctness, but the default is preserved so no existing user pays a regression risk.

## Impact (downstream measurement)

In a Cheddar Flow umbrella with several cache apps, setting `sandbox_sleep_ms: 0` saved:

| App | Before | After |
|-----|--------:|------:|
| `last_symbol_price_cache` (10 tests) | 10 × 102 ms = 1,020 ms | 10 × ~0.4 ms = 4 ms |
| `open_interest_cache` (10 tests) | 10 × 51 ms = 510 ms | 9 × <1 ms + 1 outlier 27 ms |
| `options_contract_expiry_cache` (3 tests) | 3 × 51 ms = 153 ms | 3 × ~0.04 ms |
| `active_symbols_cache` (4 tests) | 4 × 51 ms = 204 ms | 4 × ~0.08 ms |

≈ **1.7 s** saved across these apps' tests per umbrella mix test invocation.

## Test plan

- [x] Default behavior unchanged: @sleep_for_sync still resolves to 50 when no config is set.
- [x] Local test suite: same flaky envelope before and after (suite has pre-existing Redis-related flakes — 4–35 failures across runs, both with and without this change).
- [ ] CI run.